### PR TITLE
Updated option-adding change trigger

### DIFF
--- a/chosen-create-option.jquery.js
+++ b/chosen-create-option.jquery.js
@@ -1265,7 +1265,9 @@
       option = $('<option />', options).attr('selected', 'selected');
       this.form_field_jq.append(option);
       this.form_field_jq.trigger("chosen:updated");
-      this.form_field_jq.trigger("change");
+      this.form_field_jq.trigger("change", {
+        'selected': options.value
+      });
       return this.search_field.trigger("focus");
     };
 


### PR DESCRIPTION
Updated the change trigger under the option adding function (ChosenOptionAdding.prototype.select_append_option) to provide the same information that the base Chosen module sends when an option is selected.
